### PR TITLE
Feature/docs

### DIFF
--- a/documents/Makefile
+++ b/documents/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/documents/conf.py
+++ b/documents/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import sphinx_rtd_theme
+import os
+import sys
+sys.path.insert(0, os.path.abspath('~/exojax'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'bepsf'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinxemoji.sphinxemoji',
+              ]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+html_logo = '_static/logo.png'

--- a/documents/developers.rst
+++ b/documents/developers.rst
@@ -1,0 +1,15 @@
+=============================
+Sphinx doc
+=============================
+
+
+To generate sphinx doc, run 
+
+.. code:: python3
+	  	  
+   python setup.py install
+   rm -rf documents/bepsf
+   sphinx-apidoc -F -o documents/bepsf src/bepsf
+   cd documents
+   make clean
+   make html

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -13,8 +13,13 @@ Contents
 ==================================
 
 
-   
-   
+.. toctree::
+   :maxdepth: 1
+   :caption: For developers:
+
+   developers.rst
+	     
+    
 .. toctree::
    :maxdepth: 1
    :caption: API:

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -1,0 +1,26 @@
+.. exojax documentation master file, created by
+   sphinx-quickstart on Mon Jan 11 14:38:51 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+
+Bayesian ePSF   
+==================================
+
+  
+Contents
+
+==================================
+
+
+   
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: API:
+
+   bepsf/bepsf.rst
+
+
+bepsf is free software made available under the MIT License. See the ``LICENSE``.
+   

--- a/documents/requirements.txt
+++ b/documents/requirements.txt
@@ -1,0 +1,4 @@
+# sphinx >=3 required by sphinx-autodoc-typehints v1.11.1 (Oct 2020)
+sphinx >=3
+sphinx_rtd_theme
+sphinxemoji

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ META_PATH = os.path.join("src", "bepsf", "__init__.py")
 CLASSIFIERS = [
     "Programming Language :: Python",
 ]
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ["corner"]
 
 # END PROJECT SPECIFIC
 HERE = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
I made a template of the sphinx doc for bepsf.
You can try to generate the docs as follows:

```sh
python setup.py install
rm -rf documents/bepsf
sphinx-apidoc -F -o documents/bepsf src/bepsf
cd documents
make clean
make html
```

sample: http://secondearths.sakura.ne.jp/bepsf/

I think it's better to use readthedoc though.